### PR TITLE
SecProcessor_GetInfo() returns the Sec API 2 adapter version

### DIFF
--- a/src/sec_adapter_processor.c
+++ b/src/sec_adapter_processor.c
@@ -340,11 +340,8 @@ Sec_Result SecProcessor_GetInfo(Sec_ProcessorHandle* processorHandle, Sec_Proces
     if (secProcInfo == NULL)
         return SEC_RESULT_INVALID_PARAMETERS;
 
-    sa_version version;
-    sa_status status = sa_get_version(&version);
-    CHECK_STATUS(status)
+    memcpy(secProcInfo->version, SEC_API_VERSION, sizeof(SEC_API_VERSION));
 
-    memcpy(secProcInfo, &version, sizeof(sa_version));
     return SEC_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
Socprovisioning is expecting the Sec API 2 version.  This is fix replaces the Sec API 3 version with the Sec API 2 version to solve the soc provisioning error.