### PR TITLE
Remove stray copy paste comment in FindSACLIENT.cmake

### DIFF
--- a/cmake/FindSACLIENT.cmake
+++ b/cmake/FindSACLIENT.cmake
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-# Find libyajl
 
 FIND_PATH(SACLIENT_INCLUDE_DIR sa.h)
 


### PR DESCRIPTION
Reason for change: Copy paste error in header for FindSACLIENT.cmake

Test procedure: N/A

Risks: N/A