### PR TITLE
fix: use dynamic future dates in key control tests

### DIFF
--- a/test/main/cpp/keyctrl.cpp
+++ b/test/main/cpp/keyctrl.cpp
@@ -23,6 +23,22 @@
 #include "sec_security_utils.h"
 #include "sign.h"
 #include "test_ctx.h"
+#include <ctime>
+#include <string>
+
+// Returns an ISO 8601 date string N years from now, e.g. "2036-03-06T00:00:00Z".
+// Used for test key validity so tests never expire.
+static std::string futureDate(int yearsFromNow) {
+    time_t now = time(nullptr);
+    struct tm t;
+    gmtime_r(&now, &t);
+    t.tm_year += yearsFromNow;
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02dZ",
+            t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+            t.tm_hour, t.tm_min, t.tm_sec);
+    return buf;
+}
 
 #define BUFFER_SIZE 4096
 
@@ -168,7 +184,7 @@ Sec_Result testKeyCtrlKeyOnlyUsage(int version, const char* alg) {
         std::string jtype = createJTypeContainer("1WXQ46EYW65SENER", "HS256", g_default_jtype_data.contentKey,
                 g_default_jtype_data.encryptionKey, "9c621060-3a17-4813-8dcb-2e9187aaa903",
                 createDefaultRights(SEC_KEYTYPE_AES_128).c_str(), SEC_FALSE, SEC_KEYUSAGE_KEY, "2010-12-09T19:53:06Z",
-                "2025-12-09T01:02:03Z", g_default_jtype_data.macKey, version, alg);
+                futureDate(10).c_str(), g_default_jtype_data.macKey, version, alg);
 
         if (jtype.empty()) {
             SEC_LOG_ERROR("CreateJTypeContainer failed");
@@ -214,7 +230,7 @@ Sec_Result testKeyCtrlUnwrapWithKeyUsage(int version, const char* alg, TestKey c
     std::string jtype = createJTypeContainer("1WXQ46EYW65SENER", "HS256", contentKey,
             g_default_jtype_data.encryptionKey, "9c621060-3a17-4813-8dcb-2e9187aaa903",
             createDefaultRights(TestCreds::getKeyType(contentKey)).c_str(), SEC_FALSE, SEC_KEYUSAGE_KEY,
-            "2010-12-09T19:53:06Z", "2025-12-09T01:02:03Z", g_default_jtype_data.macKey, version, alg);
+            "2010-12-09T19:53:06Z", futureDate(10).c_str(), g_default_jtype_data.macKey, version, alg);
 
     if (jtype.empty()) {
         SEC_LOG_ERROR("CreateJTypeContainer failed");
@@ -298,7 +314,7 @@ Sec_Result testKeyCtrlUnwrapWithDataUsage(int version, const char* alg) {
         jtype = createJTypeContainer("1WXQ46EYW65SENER", "HS256", g_default_jtype_data.contentKey,
                 g_default_jtype_data.encryptionKey, "9c621060-3a17-4813-8dcb-2e9187aaa903",
                 createDefaultRights(SEC_KEYTYPE_AES_128).c_str(), SEC_TRUE, SEC_KEYUSAGE_DATA, "2010-12-09T19:53:06Z",
-                "2025-12-09T01:02:03Z", g_default_jtype_data.macKey, version, alg);
+                futureDate(10).c_str(), g_default_jtype_data.macKey, version, alg);
         if (jtype.empty()) {
             SEC_LOG_ERROR("CreateJTypeContainer failed");
             return SEC_RESULT_FAILURE;
@@ -529,7 +545,8 @@ Sec_Result testKeyCtrlExpectedJTypeProperties(int version, const char* alg, Test
     TestCtx ctx;
     Sec_KeyHandle* keyHandle = nullptr;
     SEC_BYTE iv[SEC_AES_BLOCK_SIZE] = {0x01};
-    const char* notOnOrAfter = "2025-12-09T19:53:06Z";
+    std::string notOnOrAfterStr = futureDate(10);
+    const char* notOnOrAfter = notOnOrAfterStr.c_str();
     const char* notBefore = "2010-12-09T19:53:06Z";
     const char* keyId = "9c621060-3a17-4813-8dcb-2e9187aaa903";
     Sec_KeyProperties keyProps;
@@ -929,7 +946,8 @@ Sec_Result testKeyCtrlExpectedExportedProperties(int version, const char* alg, T
     std::string b64rights;
     Sec_KeyHandle* keyHandle = nullptr;
     SEC_BYTE iv[SEC_AES_BLOCK_SIZE] = {0x01};
-    const char* notOnOrAfter = "2025-12-09T19:53:06Z";
+    std::string notOnOrAfterStr = futureDate(10);
+    const char* notOnOrAfter = notOnOrAfterStr.c_str();
     const char* notBefore = "2010-12-09T19:53:06Z";
     const char* keyId = "9c621060-3a17-4813-8dcb-2e9187aaa903";
     Sec_KeyProperties keyProps;
@@ -1038,7 +1056,8 @@ Sec_Result testKeyCtrlExportProvisionExport(int version, const char* alg, TestKe
     std::string b64rights;
     Sec_KeyHandle* keyHandle = nullptr;
     SEC_BYTE iv[SEC_AES_BLOCK_SIZE] = {0x01};
-    const char* notOnOrAfter = "2025-12-09T19:53:06Z";
+    std::string notOnOrAfterStr = futureDate(10);
+    const char* notOnOrAfter = notOnOrAfterStr.c_str();
     const char* notBefore = "2010-12-09T19:53:06Z";
     const char* keyId = "9c621060-3a17-4813-8dcb-2e9187aaa903";
     Sec_KeyProperties keyProps;
@@ -1170,7 +1189,8 @@ Sec_Result testKeyCtrlKeyExportGetSize(int version, const char* alg) {
     std::string b64rights;
     Sec_KeyHandle* keyHandle = nullptr;
     SEC_BYTE iv[SEC_AES_BLOCK_SIZE] = {0x01};
-    const char* notOnOrAfter = "2025-12-09T19:53:06Z";
+    std::string notOnOrAfterStr = futureDate(10);
+    const char* notOnOrAfter = notOnOrAfterStr.c_str();
     const char* notBefore = "2010-12-09T19:53:06Z";
     const char* keyId = "9c621060-3a17-4813-8dcb-2e9187aaa903";
     Sec_KeyProperties keyProps;

--- a/test/main/cpp/keyctrl.cpp
+++ b/test/main/cpp/keyctrl.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2023 Comcast Cable Communications Management, LLC
+ * Copyright 2020-2026 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace hardcoded not_on_or_after dates with a runtime-computed date (now + 10 years) so tests never expire. The previous hardcoded date of 2025-12-09 had already expired, causing testKeyCtrlUnwrapWithKeyUsage and related tests to fail with 'rights_allowed_time' errors.

Fixes #73