### PR TITLE
Fix/hkdf null salt openssl3

### DIFF
--- a/test/main/cpp/exchange.cpp
+++ b/test/main/cpp/exchange.cpp
@@ -393,12 +393,12 @@ static Sec_Result hkdf(SEC_BYTE* key, SEC_SIZE key_len, SEC_BYTE* out, const SEC
         return SEC_RESULT_FAILURE;
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000
-    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, reinterpret_cast<const unsigned char*>(use_salt ? "salt" : nullptr),
+    // OpenSSL 3.x OSSL_PARAM_construct_octet_string() rejects NULL data pointer
+    // even when length is 0, causing EVP_PKEY_CTX_set1_hkdf_salt() to fail.
+    // Pass "" instead of nullptr to satisfy the non-NULL check.
+    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx,
+                reinterpret_cast<const unsigned char*>(use_salt ? "salt" : ""),
                 use_salt ? 4 : 0) <= 0) {
-#else
-    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, use_salt ? "salt" : nullptr, use_salt ? 4 : 0) <= 0) {
-#endif
         EVP_PKEY_CTX_free(pctx);
         return SEC_RESULT_FAILURE;
     }

--- a/test/main/cpp/exchange.cpp
+++ b/test/main/cpp/exchange.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Comcast Cable Communications Management, LLC
+ * Copyright 2020-2026 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Fix 8 DH/ECDH key exchange test failures on OpenSSL 3.x when `useSalt=SEC_FALSE`.

## Problem

The `hkdf()` function in `exchange.cpp` passes `nullptr` to
`EVP_PKEY_CTX_set1_hkdf_salt()` when no salt is used. OpenSSL 3.x rejects
a NULL pointer even with length 0, causing all `testKeyExchangeDH` and
`testKeyExchangeECDH` tests with `SEC_FALSE` to fail.

## Fix

Replace `nullptr` with `""` (empty string) for the no-salt case. This provides
a valid non-NULL pointer with length 0, which both OpenSSL 1.1.x and 3.x accept.
The version-specific `#if`/`#else` guard for this call is no longer needed and
has been removed.

Also added descriptive comments to all remaining `#if`/`#else`/`#endif` blocks.

## Testing

Verified 8/8 affected tests pass on:
- OpenSSL 1.1.1w
- OpenSSL 3.0.15
- OpenSSL 3.0.18
- OpenSSL 3.6.1

Fixes #75

## Test Results: DH/ECDH Key Exchange (Tests 1193–1207)

### Affected Tests

| Test # | Function | Key Type | Salt | Type |
|--------|----------|----------|------|------|
| 1193 | `testKeyExchangeDH` | `AES_128` | `SEC_FALSE` | DH |
| 1195 | `testKeyExchangeDH` | `AES_256` | `SEC_FALSE` | DH |
| 1197 | `testKeyExchangeDH` | `HMAC_128` | `SEC_FALSE` | DH |
| 1199 | `testKeyExchangeDH` | `HMAC_256` | `SEC_FALSE` | DH |
| 1201 | `testKeyExchangeECDH` | `AES_128` | `SEC_FALSE` | ECDH |
| 1203 | `testKeyExchangeECDH` | `AES_256` | `SEC_FALSE` | ECDH |
| 1205 | `testKeyExchangeECDH` | `HMAC_128` | `SEC_FALSE` | ECDH |
| 1207 | `testKeyExchangeECDH` | `HMAC_256` | `SEC_FALSE` | ECDH |

### Results Matrix

### Without fix (main branch)

| Platform | OpenSSL | Result |
|----------|---------|--------|
| macOS (ARM64) | 1.1.1w | 8/8 passed |
| macOS (ARM64) | 3.0.15 | 8/8 passed |
| macOS (ARM64) | 3.0.18 | 0/8 passed |
| macOS (ARM64) | 3.6.1   | 0/8 passed |
| ARM32 device | 3.0.18 | 0/8 passed |

### With fix (PR #76)

| Platform | OpenSSL | Result |
|----------|---------|--------|
| macOS (ARM64) | 1.1.1w | 8/8 passed |
| macOS (ARM64) | 3.0.15 | 8/8 passed |
| macOS (ARM64) | 3.0.18 | 8/8 passed |
| macOS (ARM64) | 3.6.1 | 8/8 passed |
| ARM32 device | 3.0.18 | 8/8 passed |
| ARM32 device | 3.6.1  | 8/8 passed |