### PR TITLE
Issue 70: Enable SVP when building tasecureapi in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         git clone https://github.com/rdkcentral/tasecureapi.git tasecureapi
         cd tasecureapi
-        cmake -S reference -B reference/cmake-build
+        cmake -S reference -B reference/cmake-build -DENABLE_SVP=ON
         cmake --build reference/cmake-build
         sudo cmake --install reference/cmake-build
     - name: Config


### PR DESCRIPTION
This fixes a CI issue until the disable SVP flag in SecAPI2 adapter can be introduced.