### PR TITLE
Issue 79: Detect use-after-free in sa_invoke

### DIFF
--- a/src/sec_adapter_processor.c
+++ b/src/sec_adapter_processor.c
@@ -163,6 +163,12 @@ Sec_Result SecProcessor_GetInstance_Directories(Sec_ProcessorHandle** processorH
         return SEC_RESULT_FAILURE;
     }
 
+    // Register handle in global list before any sa_invoke calls during init
+    pthread_mutex_lock(&mutex);
+    newProcessorHandle->nextHandle = processorHandleList;
+    processorHandleList = newProcessorHandle;
+    pthread_mutex_unlock(&mutex);
+
     /* generate sec store proc ins */
     result = SecStore_GenerateLadderInputs(newProcessorHandle, SEC_STORE_AES_LADDER_INPUT, NULL,
             (SEC_BYTE*) &derived_inputs, sizeof(derived_inputs));
@@ -238,10 +244,6 @@ Sec_Result SecProcessor_GetInstance_Directories(Sec_ProcessorHandle** processorH
         return result;
     }
 
-    pthread_mutex_lock(&mutex);
-    newProcessorHandle->nextHandle = processorHandleList;
-    processorHandleList = newProcessorHandle;
-    pthread_mutex_unlock(&mutex);
     *processorHandle = newProcessorHandle;
     return SEC_RESULT_SUCCESS;
 }
@@ -640,12 +642,33 @@ sa_status sa_invoke(Sec_ProcessorHandle* processorHandle, SA_COMMAND_ID command_
     if (processorHandle == NULL)
         return SA_STATUS_INVALID_PARAMETER;
 
+    // Validate processorHandle is still in the global list before locking
+    pthread_mutex_lock(&mutex);
+    Sec_ProcessorHandle* tempHandle = processorHandleList;
+    bool handle_found = false;
+    while (tempHandle != NULL) {
+        if (tempHandle == processorHandle) {
+            handle_found = true;
+            break;
+        }
+        tempHandle = tempHandle->nextHandle;
+    }
+
+    if (!handle_found) {
+        pthread_mutex_unlock(&mutex);
+        SEC_LOG_ERROR("Use after processor handle free detected %u", command_id);
+        return SA_STATUS_INVALID_PARAMETER;
+    }
+
+    // Now safely lock the processor mutex while still holding global mutex
+    pthread_mutex_lock(&processorHandle->mutex);
+    pthread_mutex_unlock(&mutex);
+
     va_list va_args;
     va_start(va_args, command_id);
     sa_command command = {command_id, &va_args, -1};
 
     bool command_queued = false;
-    pthread_mutex_lock(&processorHandle->mutex);
     while (!processorHandle->shutdown && command.result == -1) {
         if (processorHandle->queue_size < MAX_QUEUE_SIZE && !command_queued) {
             processorHandle->queue[(processorHandle->queue_front + processorHandle->queue_size) % MAX_QUEUE_SIZE] =

--- a/test/main/cpp/processor.cpp
+++ b/test/main/cpp/processor.cpp
@@ -149,7 +149,6 @@ Sec_Result testProcessorUseAfterFree() {
     }
 
     // Attempt to use the freed handle - sa_invoke should detect this and return failure
-    Sec_KeyHandle* keyHandle = nullptr;
     Sec_Result result = SecKey_Generate(dangling, SEC_OBJECTID_USER_BASE, SEC_KEYTYPE_AES_128,
             SEC_STORAGELOC_RAM);
     if (result == SEC_RESULT_SUCCESS) {

--- a/test/main/cpp/processor.cpp
+++ b/test/main/cpp/processor.cpp
@@ -132,3 +132,30 @@ Sec_Result testProcessorInitReleaseInit() {
 
     return SEC_RESULT_SUCCESS;
 }
+
+Sec_Result testProcessorUseAfterFree() {
+    Sec_ProcessorHandle* proc = nullptr;
+    if (SecProcessor_GetInstance_Directories(&proc, nullptr, nullptr) != SEC_RESULT_SUCCESS) {
+        SEC_LOG_ERROR("SecProcessor_GetInstance_Directories failed");
+        return SEC_RESULT_FAILURE;
+    }
+
+    // Save the handle pointer before releasing
+    Sec_ProcessorHandle* dangling = proc;
+
+    if (SecProcessor_Release(proc) != SEC_RESULT_SUCCESS) {
+        SEC_LOG_ERROR("SecProcessor_Release failed");
+        return SEC_RESULT_FAILURE;
+    }
+
+    // Attempt to use the freed handle - sa_invoke should detect this and return failure
+    Sec_KeyHandle* keyHandle = nullptr;
+    Sec_Result result = SecKey_Generate(dangling, SEC_OBJECTID_USER_BASE, SEC_KEYTYPE_AES_128,
+            SEC_STORAGELOC_RAM);
+    if (result == SEC_RESULT_SUCCESS) {
+        SEC_LOG_ERROR("SecKey_Generate should have failed on a freed handle");
+        return SEC_RESULT_FAILURE;
+    }
+
+    return SEC_RESULT_SUCCESS;
+}

--- a/test/main/cpp/processor.h
+++ b/test/main/cpp/processor.h
@@ -33,4 +33,6 @@ Sec_Result testProcessorGetInfo();
 
 Sec_Result testProcessorInitReleaseInit();
 
+Sec_Result testProcessorUseAfterFree();
+
 #endif // PROCESSOR_H

--- a/test/main/cpp/sec_api_utest_main.cpp
+++ b/test/main/cpp/sec_api_utest_main.cpp
@@ -50,6 +50,7 @@ void runProcessorTests(SuiteCtx* suite) {
     RUN_TEST(suite, testProcessorGetKeyLadderMinMaxDepth(SEC_KEYLADDERROOT_SHARED))
     RUN_TEST(suite, testProcessorNativeMallocFree())
     RUN_TEST(suite, testProcessorInitReleaseInit())
+    RUN_TEST(suite, testProcessorUseAfterFree())
 }
 
 void runBundleTests(SuiteCtx* suite) {


### PR DESCRIPTION
Validate that processorHandle is still in the global processorHandleList before accessing its fields. This prevents undefined behavior when sa_invoke is called with a dangling pointer to a freed handle.