### PR TITLE
Bump version 2.4.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ add_library(sec_api SHARED
 set_target_properties(sec_api PROPERTIES
         LINKER_LANGUAGE C
         SO_VERSION 2.4
-        VERSION 2.4.3.0
+        VERSION 2.4.4.0
         )
 
 target_compile_options(sec_api PRIVATE -Wno-deprecated-declarations)

--- a/include/sec_version.h
+++ b/include/sec_version.h
@@ -16,4 +16,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define SEC_API_VERSION "2.4.3.0"
+#define SEC_API_VERSION "2.4.4.0"


### PR DESCRIPTION
## Summary
Bump secapi2-adapter version from 2.4.3.0 to 2.4.4.0.

## Changes
- CMakeLists.txt: VERSION 2.4.3.0 → 2.4.4.0
- include/sec_version.h: SEC_API_VERSION 2.4.3.0 → 2.4.4.0

Reason for change: Update version numbers
Risks: None